### PR TITLE
[TDO-302] Change handling of multiple filters from AND to OR

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "harrietrc/gdpr-dump",
+    "name": "serato/gdpr-dump",
     "description": "A utility to create anonymized database dumps. Forked from smile/gdpr-dump",
     "type": "library",
     "license": "GPL-3.0-or-later",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "smile/gdpr-dump",
-    "description": "A utility to create anonymized database dumps",
+    "name": "harrietrc/gdpr-dump",
+    "description": "A utility to create anonymized database dumps. Forked from smile/gdpr-dump",
     "type": "library",
     "license": "GPL-3.0-or-later",
     "authors": [

--- a/packages.json
+++ b/packages.json
@@ -1,0 +1,12 @@
+{
+  "packages": {
+    "harrietrc/gdpr-dump": {
+      "dev-master": {
+        "name": "harrietrc/gdpr-dump",
+        "repository": {"type": "git", "url": "git://github.com/harrietrc/gdpr-dump.git"},
+        "type": "project",
+        "version": "dev-master"
+      }
+    }
+  }
+}

--- a/packages.json
+++ b/packages.json
@@ -1,9 +1,9 @@
 {
   "packages": {
-    "harrietrc/gdpr-dump": {
+    "serato/gdpr-dump": {
       "dev-master": {
-        "name": "harrietrc/gdpr-dump",
-        "repository": {"type": "git", "url": "git://github.com/harrietrc/gdpr-dump.git"},
+        "name": "serato/gdpr-dump",
+        "repository": {"type": "git", "url": "git://github.com/serato/gdpr-dump.git"},
         "type": "project",
         "version": "dev-master"
       }

--- a/src/Dumper/Mysqldump/TableFilterExtension.php
+++ b/src/Dumper/Mysqldump/TableFilterExtension.php
@@ -222,7 +222,7 @@ class TableFilterExtension implements ExtensionInterface
                 [$this->connection->quoteIdentifier($filter->getColumn()), $value]
             );
 
-            $queryBuilder->andWhere($whereExpr);
+            $queryBuilder->orWhere($whereExpr);
         }
 
         // Apply sort orders

--- a/tests/functional/Dumper/SqlDumperTest.php
+++ b/tests/functional/Dumper/SqlDumperTest.php
@@ -90,8 +90,9 @@ class SqlDumperTest extends TestCase
         $this->assertStringContainsString('store2', $output);
         $this->assertStringNotContainsString('store3', $output);
 
-        // User 1 must not be dumped (does not match the date filter)
-        $this->assertStringNotContainsString('user1@test.org', $output);
+        // User 1 should be dumped, now that filters are now 'ORed' rather than 'ANDed'. The first filter will match the
+        // customer's email address, but the second will not match their `created_at` date.
+        $this->assertStringContainsString('user1@test.org', $output);
 
         // User 2 must be dumped, but not anonymized (skip_conversion_if parameter)
         $this->assertStringContainsString('user2@test.org', $output);
@@ -127,8 +128,6 @@ class SqlDumperTest extends TestCase
         $this->assertStringContainsString('street7', $output);
 
         if ($filterPropagationEnabled) {
-            $this->assertStringNotContainsString('street1', $output);
-            $this->assertStringNotContainsString('street2', $output);
             $this->assertStringNotContainsString('street8', $output);
             $this->assertStringNotContainsString('street9', $output);
         } else {


### PR DESCRIPTION
- Filters are now 'ORed' rather than 'ANDed', allowing us to broaden the subset of rows we include in our database dumps
- Tweaks to unit tests

(I don't have write permissions on serato/gdpr-dump but a PR is a good idea, anyway)

@electric, sorry for yet another PR review!